### PR TITLE
sqs.client: fix consumer and producer leak on connect call

### DIFF
--- a/src/sqs.client.ts
+++ b/src/sqs.client.ts
@@ -66,7 +66,9 @@ export class SqsClient extends ClientProxy {
   }
 
   public connect(): Promise<any> {
-    this.createClient();
+    if (!this.producer) {
+      this.createClient();
+    }
     return Promise.resolve();
   }
 


### PR DESCRIPTION
During each ClientProxy emit `connect` method of underlying implementation
is called. SqsClient `connect` method calls `createClient` which creates
new consumer and producer. ClientProxy is not calling `close` on emit
which leads to leak of the consumer which is created during emit but
is never disposed and reference to the object is lost. This leads on absurdly
slow emits after `n` events sent and leak of resources.